### PR TITLE
Paypal error 10426 without round

### DIFF
--- a/Controller/GotoPaypal.php
+++ b/Controller/GotoPaypal.php
@@ -107,7 +107,7 @@ class GotoPaypal extends BaseFrontController
          */
         $setExpressCheckout = new PaypalNvpOperationsSetExpressCheckout(
             $api,
-            $order->getTotalAmount(),
+            round($order->getTotalAmount(), 2),
             $order->getCurrency()->getCode(),
             Paypal::getPaypalURL('paiement', $order_id),
             Paypal::getPaypalURL('cancel', $order_id),
@@ -117,7 +117,7 @@ class GotoPaypal extends BaseFrontController
                 "PAYMENTREQUEST"=>array(
                     array(
                         "SHIPPINGAMT"=>$order->getPostage(),
-                        "ITEMAMT"=>$order->getTotalAmount($useless,false)
+                        "ITEMAMT"=>round($order->getTotalAmount($useless,false), 2)
                     )
                 )
             )

--- a/Controller/GotoPaypal.php
+++ b/Controller/GotoPaypal.php
@@ -85,7 +85,7 @@ class GotoPaypal extends BaseFrontController
                 }
                 $products_amount+=$amount*$product->getQuantity();
                 $products[0]["NAME".$i]=urlencode($product->getTitle());
-                $products[0]["AMT".$i]=urlencode($amount);
+                $products[0]["AMT".$i]=urlencode(round($amount, 2));
                 $products[0]["QTY".$i]=urlencode($product->getQuantity());
                 $i++;
             }
@@ -116,7 +116,7 @@ class GotoPaypal extends BaseFrontController
                 "L_PAYMENTREQUEST"=>$products,
                 "PAYMENTREQUEST"=>array(
                     array(
-                        "SHIPPINGAMT"=>$order->getPostage(),
+                        "SHIPPINGAMT"=>round($order->getPostage(), 2),
                         "ITEMAMT"=>round($order->getTotalAmount($useless,false), 2)
                     )
                 )

--- a/Controller/PaypalResponse.php
+++ b/Controller/PaypalResponse.php
@@ -97,7 +97,7 @@ class PaypalResponse extends BasePaymentModuleController
 
                 $doExpressCheckout = new PaypalNvpOperationsDoExpressCheckoutPayment(
                     $api,
-                    $order->getTotalAmount(),
+                    round($order->getTotalAmount(), 2),
                     $order->getCurrency()->getCode(),
                     $payerid,
                     PaypalApiManager::PAYMENT_TYPE_SALE,


### PR DESCRIPTION
Transaction Failure correlationId: 68d0a0613f20e error: [10426]
<Transaction refused because of an invalid argument. See additional
error messages for details.> Item total is invalid.