### PR TITLE
arrondi

### DIFF
--- a/Controller/PaypalResponse.php
+++ b/Controller/PaypalResponse.php
@@ -97,7 +97,7 @@ class PaypalResponse extends BasePaymentModuleController
 
                 $doExpressCheckout = new PaypalNvpOperationsDoExpressCheckoutPayment(
                     $api,
-                    $order->getTotalAmount(),
+                    round($order->getTotalAmount(),2),
                     $order->getCurrency()->getCode(),
                     $payerid,
                     PaypalApiManager::PAYMENT_TYPE_SALE,


### PR DESCRIPTION
arrondir pour que si il y a des pourcentages de réduction le total du panier et le total calculé par rapport aux articles soit égale sinon ça peut être différent et donc la commande fausse
