### PR TITLE
arrondi

### DIFF
--- a/Controller/GotoPaypal.php
+++ b/Controller/GotoPaypal.php
@@ -86,7 +86,7 @@ class GotoPaypal extends BaseFrontController
                 }
                 $products_amount+=$amount*$product->getQuantity();
                 $products[0]["NAME".$i]=urlencode($product->getTitle());
-                $products[0]["AMT".$i]=urlencode($amount);
+                $products[0]["AMT".$i]=urlencode(round($amount,2));
                 $products[0]["QTY".$i]=urlencode($product->getQuantity());
                 $i++;
             }
@@ -108,7 +108,7 @@ class GotoPaypal extends BaseFrontController
          */
         $setExpressCheckout = new PaypalNvpOperationsSetExpressCheckout(
             $api,
-            $order->getTotalAmount(),
+            round($order->getTotalAmount(),2),
             $order->getCurrency()->getCode(),
             Paypal::getPaypalURL('paiement', $order_id),
             Paypal::getPaypalURL('cancel', $order_id),
@@ -117,8 +117,8 @@ class GotoPaypal extends BaseFrontController
                 "L_PAYMENTREQUEST"=>$products,
                 "PAYMENTREQUEST"=>array(
                     array(
-                        "SHIPPINGAMT"=>$order->getPostage(),
-                        "ITEMAMT"=>$order->getTotalAmount($useless, false)
+                        "SHIPPINGAMT"=>round($order->getPostage(),2),
+                        "ITEMAMT"=>round($order->getTotalAmount($useless, false),2)
                     )
                 )
             )


### PR DESCRIPTION
arrondir pour que si il y a des pourcentages de réduction le total du panier et le total calculé par rapport aux articles soit égale sinon ça peut être différent et donc la commande fausse
