### PR TITLE
Fix bug with difference between total product and order amount

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0</version>
+    <version>2.1</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>

--- a/Paypal.php
+++ b/Paypal.php
@@ -91,9 +91,10 @@ class Paypal extends AbstractPaymentModule
                 foreach ($product->getOrderProductTaxes() as $tax) {
                     $amount += $product->getWasInPromo() ? $tax->getPromoAmount() : $tax->getAmount();
                 }
-                $products_amount += $amount * $product->getQuantity();
+                $rounded_amounts = round($amount, 2);
+                $products_amount += $rounded_amounts * $product->getQuantity();
                 $products[0][ "NAME" . $itemIndex ] = urlencode($product->getTitle());
-                $products[0][ "AMT" . $itemIndex ]  = urlencode(round($amount, 2));
+                $products[0][ "AMT" . $itemIndex ]  = urlencode($rounded_amounts);
                 $products[0][ "QTY" . $itemIndex ]  = urlencode($product->getQuantity());
                 $itemIndex ++;
             }


### PR DESCRIPTION
This happen because each price for products is rounded before send it to Paypal but the $products_amount used to find delta and discount is computed from addition of products prices not rounded. 
So in some case the $products_amount is not equal to real addition of products this cause a false delta and add a fake product "discount" to compense where is not needed. And the total of products is not equal to order amount.