### PR TITLE
Fix get lang in payment form

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>3.0.4</version>
+    <version>3.0.5</version>
     <authors>
         <author>
             <name>gbarral</name>

--- a/EventListeners/Form/TheliaOrderPaymentForm.php
+++ b/EventListeners/Form/TheliaOrderPaymentForm.php
@@ -125,7 +125,7 @@ class TheliaOrderPaymentForm implements EventSubscriberInterface
         $session = $this->requestStack->getCurrentRequest()->getSession();
 
         /** @var \Thelia\Model\Lang $lang */
-        $lang = $session->get('thelia.current.lang');
+        $lang = $session->getLang();
 
         /** @var Cart $cart */
         $cart = $session->getSessionCart($this->dispatcher);


### PR DESCRIPTION
Fix old `$session->get('thelia.current.lang');` that causes exceptions when no lang was set.