### PR TITLE
NVP messages sent with POST

### DIFF
--- a/Classes/NVP/PaypalNvpMessageSender.php
+++ b/Classes/NVP/PaypalNvpMessageSender.php
@@ -23,8 +23,8 @@
 
 namespace Paypal\Classes\NVP;
 
-use Paypal\Classes\NVP\Operations\PaypalNvpOperationInterface;
 use Paypal\Classes\API\PaypalApiManager;
+use Paypal\Classes\NVP\Operations\PaypalNvpOperationInterface;
 
 /**
  * Class PaypalNvpMessageSender
@@ -72,10 +72,19 @@ class PaypalNvpMessageSender
     {
         $paypalApiManager = new PaypalApiManager();
 
-        $url = $paypalApiManager->getApiUrl() . '?' . $this->message;
+        $url = $paypalApiManager->getApiUrl();
 
         $ch = curl_init($url);
+
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->message);
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
         $response = curl_exec($ch);
 
         return $response;

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>

--- a/Controller/PaypalResponse.php
+++ b/Controller/PaypalResponse.php
@@ -105,6 +105,7 @@ class PaypalResponse extends BasePaymentModuleController
                         $payerid,
                         PaypalApiManager::PAYMENT_TYPE_SALE,
                         $token,
+                        // FIXME This URL is not used in PaypalNvpOperationsDoExpressCheckoutPayment, and has no defined route
                         URL::getInstance()->absoluteUrl("/module/paypal/listen"),
                         PaypalApiManager::BUTTON_SOURCE
                     );

--- a/templates/email/default/paypal-payment-confirmation.html
+++ b/templates/email/default/paypal-payment-confirmation.html
@@ -15,7 +15,7 @@
 {block name="email-content"}
     <p>
         <a href="{url path="/account"}">
-            {intl l="View this order in your account at %shop_name" shop_name={config key="store_name"}}
+            {intl d='paypal.email.default' l="View this order in your account at %shop_name" shop_name={config key="store_name"}}
         </a>
     </p>
     <p>{intl d='paypal.email.default' l='Thank you again for your purchase.'}</p>

--- a/templates/email/default/paypal-payment-confirmation.txt
+++ b/templates/email/default/paypal-payment-confirmation.txt
@@ -1,9 +1,9 @@
 {intl d='paypal.email.default' l='Dear customer'},
-
+<br>
 {intl d='paypal.email.default' l='This is a confirmation of the payment of your order %ref via Paypal on our shop.' ref=$order_ref}
-
+<br>
 {intl d='paypal.email.default' l='Your invoice is now available in your customer account at %url.'} url={config key="url_site"}}
-
+<br>
 {intl d='paypal.email.default' l='Thank you again for your purchase.'}
-
+<br>
 {intl d='paypal.email.default' l='The %store_name team.' store_name={config key="store_name"}}


### PR DESCRIPTION
The NVP messages are now sent using POST method to be compliant with June 2018 PayPal requirements.